### PR TITLE
Remove close-handler for powershell child process

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -415,9 +415,6 @@ function powerShellStart() {
       _psChild.on('error', function () {
         powerShellProceedResults(_psResult + _psError);
       });
-      _psChild.on('close', function () {
-        _psChild.kill();
-      });
     }
   }
 }


### PR DESCRIPTION
2 problems could arise in the close-event handler if powerShellStart() is called after powerShellRelease():

1. the variable _psChild could be null if the close-event was fired after the null assignment but before the spawn() call returns. (in my tests when powerShellStart is called 1s after powerShellRelease).

2. the signal from the kill()-call could be delivered to the newly created powershell subprocess. (in my tests when powerShellStart is called directly after powerShellRelease).

In my view, the close handler is not necessary.